### PR TITLE
Apply PR template when PRs are created via `fel submit`

### DIFF
--- a/fel/submit.py
+++ b/fel/submit.py
@@ -70,9 +70,18 @@ def submit(repo, c, gh, upstream, branch_prefix, update_only=False):
         diff_branch.set_tracking_branch(push_info[0].remote_ref)
 
         # Push branch to GitHub to create PR. 
-        summary, body = c.message.split('\n', 1)
+        summary, commit_body = c.message.split('\n', 1)
+        pr_body = commit_body
+        
+        # If this repo has a pull request template, apply it to PR
+        try:
+            pr_template = repo.git.show('HEAD:.github/pull_request_template.md')
+            if pr_template:
+                pr_body = commit_body + '\n\n' + pr_template
+        except:
+            pass
         pr = gh.create_pull(title=summary,
-                            body=body,
+                            body=pr_body,
                             head=diff_branch.tracking_branch().remote_head,
                             base=base_ref.tracking_branch().remote_head)
 


### PR DESCRIPTION
It'd be super awesome if the repo's PR template was automatically applied when creating a new PR.

This adds the PR template (if one exists) to the PR body, after the commit description

Example: https://github.com/replit/repl-it-web/pull/10103