### PR TITLE
Don't fail when landing in a repo that deletes on merge

### DIFF
--- a/fel/land.py
+++ b/fel/land.py
@@ -1,5 +1,7 @@
 import logging
 
+from github.GithubException import UnknownObjectException
+
 from .meta import parse_meta
 from .rebase import subtree_graft
 from .submit import submit
@@ -67,8 +69,11 @@ def land(repo, commit, gh_repo, upstream, branch_prefix):
                 # If a commit hasn't been submitted yet, skip it
                 pass
 
-        # Delete the remote branch
-        gh_repo.get_git_ref("heads/{}".format(pr.head.ref)).delete()
+        try:
+            # Delete the remote branch
+            gh_repo.get_git_ref("heads/{}".format(pr.head.ref)).delete()
+        except UnknownObjectException:
+            logging.debug("Remote branch was already deleted")
 
     except KeyError:
         logging.error("Cant land unsubmitted commit")


### PR DESCRIPTION


[#]:fel

---
This diff is part of a [fel stack](https://github.com/zabot/fel)
<pre>
* <a href="19">#19 Check mergeability before landing</a>
* <a href="18">#18 Improved mergeability checks</a>
* <a href="17">#17 Admin merge behind a flag</a>
* <a href="16">#16 Display colored mergability in fel status</a>
* <a href="15">#15 Use PR template when submitting commits</a>
* <a href="13">#13 Handle https repos</a>
* <a href="11">#11 Move configuration into module</a>
* <a href="10">#10 Don't fail when landing in a repo that deletes on merge</a>
* master
</pre>
