### PR TITLE
Check mergeability before landing

### DIFF
--- a/fel/__main__.py
+++ b/fel/__main__.py
@@ -62,7 +62,7 @@ def _status(repo, gh_repo, __, config):
 
             pr = gh_repo.get_pull(pr_num)
 
-            mergeable, message, temp = is_mergeable(pr, upstream)
+            mergeable, message, temp = is_mergeable(gh_repo, pr, upstream)
 
             m = ""
             if mergeable:

--- a/fel/mergeability.py
+++ b/fel/mergeability.py
@@ -1,3 +1,9 @@
+import time
+from datetime import datetime, timedelta
+
+from github.GithubException import GithubException
+from yaspin import yaspin
+
 # Returns two booleans. The first indicates if the PR is mergable, the second
 # indicates if the lack of mergability is worth waiting for
 #
@@ -5,7 +11,7 @@
 # is blocked from landing, and even if it did, fel branches don't play well
 # with the branch protection rules. So we need to evaluate the branch
 # protection rules ourself.
-def is_mergeable(pr, upstream):
+def is_mergeable(gh_repo, pr, upstream):
     # Before we do anything, check for conflicts
     if not pr.mergeable:
         return False, "Merge conflicts", False
@@ -22,20 +28,31 @@ def is_mergeable(pr, upstream):
 
     # If there are any changes requested, we can't merge
     if changes_requested > 0:
-        return False, "Changes requested", True
+        return False, "Changes requested", False
 
     # Get the branch protection configuration of the upstream branch
     # (This may not be the base of the PR, since the entire stack will eventually
     # be merged into the same branch, we check against the protection rules of
     # the final branch)
     upstream = pr.base.repo.get_branch(upstream)
-    protection = upstream.get_protection()
 
-    # Check for required number of approvals
-    required_approvals = protection.required_pull_request_reviews
-    if required_approvals != None:
-        if approved < required_approvals.required_approving_review_count:
-            return False, "Review required", True
+    try:
+        protection = upstream.get_protection()
+
+        # Check for required number of approvals
+        required_approvals = protection.required_pull_request_reviews
+        if required_approvals != None:
+            if approved < required_approvals.required_approving_review_count:
+                return False, "Review required", False
+
+        required_checks = set()
+
+        if protection.required_status_checks:
+            required_checks = set(protection.required_status_checks.contexts)
+
+    except GithubException:
+        # If there are no branch protection rules, no checks are required
+        required_checks = set()
 
     # PR is ready to merge, lets make sure checks are passing
     commits = pr.get_commits()
@@ -45,11 +62,13 @@ def is_mergeable(pr, upstream):
     pending = 0
     failed = 0
     total = 0
-    required_checks = set(protection.required_status_checks.contexts)
     for check in latest.get_check_runs():
         total += 1
 
-        required_checks.remove(check.name)
+        try:
+            required_checks.remove(check.name)
+        except KeyError:
+            pass
 
         if check.status != 'completed':
             pending += 1
@@ -62,6 +81,12 @@ def is_mergeable(pr, upstream):
     # If the PR doesn't have the required checks run on it, we may not be close
     # enough to the upstream branch to trigger the checks to run.
     if required_checks:
+        # If the PR was just updated, its possible that required checks haven't
+        # been started yet. Give required checks a window of time to become
+        # pending before failing for missing checks.
+        if datetime.utcnow() - pr.updated_at < timedelta(seconds=10):
+            return False, "Missing required checks", True
+
         return False, "Missing required checks", False
 
     if pending > 0:
@@ -71,6 +96,7 @@ def is_mergeable(pr, upstream):
         return False, "Checks failed ({} / {})".format(total - failed, total), False
 
     # If we've checked everything, and the PR is still blocked, give up and notify
+    pr = gh_repo.get_pull(pr.number)
     if pr.mergeable_state != 'clean':
         return False, "Unknown", False
 
@@ -80,3 +106,25 @@ def is_mergeable(pr, upstream):
     assert pr.mergeable_state == 'clean'
 
     return True, "", False
+
+def wait_for_checks(gh_repo, pr, upstream, poll_interval=5):
+    mergeable, status, wait = is_mergeable(gh_repo, pr, upstream)
+
+    with yaspin(text="#{} {}".format(pr.number, status), color='yellow') as sp:
+        while wait:
+            sp.text = "#{} {}".format(pr.number, status)
+            pr = gh_repo.get_pull(pr.number)
+            mergeable, status, wait = is_mergeable(gh_repo, pr, upstream)
+
+            if wait:
+                time.sleep(poll_interval)
+
+        sp.text = ''
+        if mergeable:
+            sp.color = 'green'
+            sp.ok("✔ #{} Passing".format(pr.number))
+            return True, ''
+        else:
+            sp.color = 'red'
+            sp.fail("✖ #{} {}".format(pr.number, status))
+            return False, status

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python = "^3.7"
 GitPython = "^3.1.14"
 PyGithub = "^1.55"
 PyYAML = "^5.4.1"
+yaspin = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/test/test_mergeability.py
+++ b/test/test_mergeability.py
@@ -1,0 +1,133 @@
+import pytest
+import datetime
+
+from unittest.mock import Mock
+
+from fel.mergeability import is_mergeable
+
+upstream = 'master'
+
+@pytest.fixture
+def gh_repo(pr):
+    gh_repo = Mock()
+    gh_repo.get_pull.return_value = pr
+    return gh_repo
+
+# Landing a pr on a branch with no protection rules and no conflicts
+def test_clean_merge(gh_repo, pr):
+    mergeable, status, wait = is_mergeable(gh_repo, pr, upstream)
+
+    assert status == ''
+    assert mergeable
+    assert not wait
+
+# Landing a pr on a branch with conflicts
+def test_conflict_merge(gh_repo, pr):
+    pr.mergeable = False
+
+    mergeable, status, wait = is_mergeable(gh_repo, pr, upstream)
+
+    assert status == 'Merge conflicts'
+    assert not mergeable
+    assert not wait
+
+# Landing a pr when changes have been requested
+def test_changes_merge(gh_repo, pr):
+    pr.get_reviews.return_value = [Mock()]
+    pr.get_reviews()[0].state = 'CHANGES_REQUESTED'
+
+    mergeable, status, wait = is_mergeable(gh_repo, pr, upstream)
+
+    assert status == 'Changes requested'
+    assert not mergeable
+    assert not wait
+
+# Landing a pr with pending checks
+def test_pending_checks(gh_repo, pr):
+    pr.get_commits()[0].get_check_runs.return_value=[Mock()]
+    pr.get_commits()[0].get_check_runs()[0].name = 'check'
+    pr.get_commits()[0].get_check_runs()[0].status = 'pending'
+    pr.get_commits()[0].get_check_runs()[0].conclusion = None
+
+    mergeable, status, wait = is_mergeable(gh_repo, pr, upstream)
+
+    assert status == 'Waiting for checks (0 / 1)'
+    assert not mergeable
+    assert wait
+
+# Landing a pr with failed checks
+def test_failed_checks(gh_repo, pr):
+    pr.get_commits()[0].get_check_runs.return_value=[Mock()]
+    pr.get_commits()[0].get_check_runs()[0].name = 'check'
+    pr.get_commits()[0].get_check_runs()[0].status = 'completed'
+    pr.get_commits()[0].get_check_runs()[0].conclusion = 'failure'
+
+    mergeable, status, wait = is_mergeable(gh_repo, pr, upstream)
+
+    assert status == 'Checks failed (0 / 1)'
+    assert not mergeable
+    assert not wait
+
+# Landing a PR to a protected branch without reviews
+def test_missing_reviews(gh_repo, ppr):
+    ppr.get_reviews.return_value = []
+    ppr.base.repo.get_branch().get_protection().required_pull_request_reviews = Mock()
+    ppr.base.repo.get_branch().get_protection().required_pull_request_reviews.required_approving_review_count = 1
+
+    mergeable, status, wait = is_mergeable(gh_repo, ppr, upstream)
+
+    assert status == 'Review required'
+    assert not mergeable
+    assert not wait
+
+# Landing a PR to a protected branch with reviews
+def test_approved_reviews(gh_repo, ppr):
+    ppr.get_reviews.return_value = [Mock]
+    ppr.get_reviews()[0].state = 'APPROVED'
+    ppr.base.repo.get_branch().get_protection().required_pull_request_reviews = Mock()
+    ppr.base.repo.get_branch().get_protection().required_pull_request_reviews.required_approving_review_count = 1
+
+    mergeable, status, wait = is_mergeable(gh_repo, ppr, upstream)
+
+    assert status == ''
+    assert  mergeable
+    assert not wait
+
+# Landing a pr with missing required status checks
+def test_missing_status(gh_repo, ppr):
+    ppr.updated_at = datetime.datetime(year=1970, month=1, day=1)
+    ppr.base.repo.get_branch().get_protection().required_status_checks = Mock()
+    ppr.base.repo.get_branch().get_protection().required_status_checks.contexts = ['check']
+
+    mergeable, status, wait = is_mergeable(gh_repo, ppr, upstream)
+
+    assert status == 'Missing required checks'
+    assert not mergeable
+    assert not wait
+
+# Landing a new pr with missing required status checks
+def test_missing_status_new_pr(gh_repo, ppr):
+    ppr.updated_at = datetime.datetime.utcnow()
+    ppr.base.repo.get_branch().get_protection().required_status_checks = Mock()
+    ppr.base.repo.get_branch().get_protection().required_status_checks.contexts = ['check']
+
+    mergeable, status, wait = is_mergeable(gh_repo, ppr, upstream)
+
+    assert status == 'Missing required checks'
+    assert not mergeable
+    assert wait
+
+# Landing a pr with passed required status checks
+def test_passed_status(gh_repo, ppr):
+    ppr.base.repo.get_branch().get_protection().required_status_checks = Mock()
+    ppr.base.repo.get_branch().get_protection().required_status_checks.contexts = ['check']
+    ppr.get_commits()[0].get_check_runs.return_value=[Mock()]
+    ppr.get_commits()[0].get_check_runs()[0].name = 'check'
+    ppr.get_commits()[0].get_check_runs()[0].status = 'completed'
+    ppr.get_commits()[0].get_check_runs()[0].conclusion = 'success'
+
+    mergeable, status, wait = is_mergeable(gh_repo, ppr, upstream)
+
+    assert status == ''
+    assert mergeable
+    assert not wait


### PR DESCRIPTION


[#]:fel

---
This diff is part of a [fel stack](https://github.com/zabot/fel)
<pre>
* <a href="21">#21 Don't trigger double CI builds on submit</a>
* <a href="19">#19 Check mergeability before landing</a>
* master
</pre>
