### PR TITLE
Display correct PR number in status

### DIFF
--- a/fel/__main__.py
+++ b/fel/__main__.py
@@ -85,6 +85,7 @@ def _status(repo, gh_repo, __, config):
                     icon = style.fail + "✖ "
 
                 status = f"{icon}{message}{style.default}"
+                pr_link = f"{gh_repo.html_url}/pull/{pr_num}"
 
                 sp[
                     commit


### PR DESCRIPTION


[#]:fel

---
This diff is part of a [fel stack](https://github.com/zabot/fel)
<pre>
* <a href="37">#37 Don't include fel metadata in pr body</a>
* <a href="38">#38 Display correct PR number in status</a>
* master
</pre>
